### PR TITLE
fix a typo in README and cabal info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 effin: Extensible Effects
 =========================
 
-This package implements extensible effects, and alternative to monad transformers.
+This package implements extensible effects, an alternative to monad transformers.
 The original paper can be found at http://okmij.org/ftp/Haskell/extensible/exteff.pdf.
 The main differences between this library and the one described in the paper are
 that this library does not use the Typeable type class, does not require that

--- a/effin.cabal
+++ b/effin.cabal
@@ -11,7 +11,7 @@ category:            Control, Effect
 build-type:          Simple
 cabal-version:       >=1.10
 description:
-  This package implements extensible effects, and alternative to monad
+  This package implements extensible effects, an alternative to monad
   transformers. The original paper can be found at
   <http://okmij.org/ftp/Haskell/extensible/exteff.pdf>. The main differences
   between this library and the one described in the paper are that this library


### PR DESCRIPTION
there was an "and" where an "an" should be
